### PR TITLE
Changed requirement to rspec/core

### DIFF
--- a/lib/rspec/eventually.rb
+++ b/lib/rspec/eventually.rb
@@ -1,5 +1,5 @@
 require 'rspec/eventually/version'
-require 'rspec'
+require 'rspec/core'
 
 module Rspec
   module Eventually


### PR DESCRIPTION
Thanks for this gem! Using it gives a failure due to a requirement on `rspec` instead of `rspec/core`. Changed that.
