### PR TITLE
Add configurable pause

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ I want to be able to do something like this:
     # Change the timeout
     expect { client.get 'ZYX' }.to eventually(eq 1).within 5
 
+    # Change the pause between retries
+    expect { client.get 'ZYX' }.to eventually(eq 1).pause_for 1.5
+
   end
 ```
 


### PR DESCRIPTION
**Problem**: When using rspec-eventually it evaluates matcher with default sleep time of 100ms. When using it with API or other HTTP calls it seems excessive to retry every 100ms.

**Solution**: add ability to configure time to pause between retries as a `Rspec::Eventually.pause` or `pause_for(X)` seconds, while maintaining default behavior

Example of usage: 

```
# Change the pause between retries
    expect { client.get 'ZYX' }.to eventually(eq 1).pause_for 1.5
```

Most of the tests that I could think of are included.
